### PR TITLE
修复utf8-bom格式的csv文件无法读取

### DIFF
--- a/v3/helper/tab_csv.go
+++ b/v3/helper/tab_csv.go
@@ -96,6 +96,11 @@ func (self *CSVFile) Load(fileName string) error {
 		return err
 	}
 
+	if len(data) > 3 {
+		if data[0] == 0xef || data[1] == 0xbb || data[2] == 0xbf {
+			data = data[3:]
+		}
+	}
 
 	self.Name = strings.TrimSuffix(fileName, filepath.Ext(fileName))
 

--- a/v3/helper/tab_csv.go
+++ b/v3/helper/tab_csv.go
@@ -97,7 +97,7 @@ func (self *CSVFile) Load(fileName string) error {
 	}
 
 	if len(data) > 3 {
-		if data[0] == 0xef || data[1] == 0xbb || data[2] == 0xbf {
+		if data[0] == 0xef && data[1] == 0xbb && data[2] == 0xbf {
 			data = data[3:]
 		}
 	}


### PR DESCRIPTION
项目中csv会以utf8-csv格式保存，方便策划打开后可以正常显示中文。